### PR TITLE
Fix deprecated support for classifier

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -96,7 +96,7 @@ afterEvaluate { project ->
     // some Gradle build hooks ref:
     // https://www.oreilly.com/library/view/gradle-beyond-the/9781449373801/ch03.html
     task androidSourcesJar(type: Jar) {
-        classifier = 'sources'
+        archiveClassifier = 'sources'
         from android.sourceSets.main.java.srcDirs
         include '**/*.java'
     }


### PR DESCRIPTION
Looks like `classifier` is deprecated in Gradle v8 and `archiveClassifier` should be used instead.